### PR TITLE
Fix compatibility with modern scikit-learn and Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 
 # Mac files
 .idea
+.DS_Store
 
 # Distribution / packaging
 .Python
@@ -50,6 +51,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+notebooks/
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ venv.bak/
 
 # Temporary install
 .unipls.egg-info
+
+# Claude config files
+.claude/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2018, Andreas Baum and Laurent Vermue
+Copyright (c) 2026, Lukas Kopecky, Imperial College London
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Installation
 -  | Install the package for Python3 using the following command. Some
      dependencies might require an upgrade (scikit-learn, numpy and
      scipy).
-   | ``$ pip install mbpls``
+   | ``$ pip install multiblock-pls``
 
 -  | Now you can import the MBPLS class by typing
    | ``from mbpls.mbpls import MBPLS``

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,11 @@ Multiblock Partial Least Squares Package
 ========================================
 
 
-.. image:: https://img.shields.io/pypi/l/mbpls.svg
-    :target: https://pypi.python.org/pypi/mbpls/
+.. image:: https://img.shields.io/pypi/v/multiblock-pls.svg
+    :target: https://pypi.python.org/pypi/multiblock-pls
+    :alt: Pypi Version
+.. image:: https://img.shields.io/pypi/l/multiblock-pls.svg
+    :target: https://pypi.python.org/pypi/multiblock-pls
     :alt: License
 .. image:: https://readthedocs.org/projects/mbpls/badge/?version=latest
     :target: https://mbpls.readthedocs.io/en/latest/?badge=latest
@@ -41,7 +44,7 @@ Installation
 -  | Install the package for Python3 using the following command. Some
      dependencies might require an upgrade (scikit-learn, numpy and
      scipy).
-   | ``$ pip install mb-pls``
+   | ``$ pip install multiblock-pls``
 
 -  | Now you can import the MBPLS class by typing
    | ``from mbpls.mbpls import MBPLS``

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Multiblock Partial Least Squares Package
 
 
 .. image:: https://img.shields.io/pypi/v/multiblock-pls.svg
-    :target: https://pypi.python.org/pypi/multiblock-pls
+    :target: https://pypi.org/project/multiblock-pls/
     :alt: Pypi Version
 .. image:: https://img.shields.io/pypi/l/multiblock-pls.svg
     :target: https://pypi.python.org/pypi/multiblock-pls

--- a/README.rst
+++ b/README.rst
@@ -13,17 +13,17 @@ Multiblock Partial Least Squares Package
    :alt: JOSS Paper DOI
 
 
-   *This is a newly maintained version of the package, based on the original
-   MBPLS software originally developed by Andreas Baum and Laurent Vermue
-   (homepabe: https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/).
-   This maintained version has been updated to be compatible with Python 3.8 and later, and modern
-   version of the dependencies. The original version of the package is no longer maintained,
-   and users are encouraged to use this updated version for their work.*
+*This is a newly maintained version of the package, based on the original
+MBPLS software originally developed by Andreas Baum and Laurent Vermue
+(homepabe: https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/).
+This maintained version has been updated to be compatible with Python 3.8 and later, and modern
+version of the dependencies. The original version of the package is no longer maintained,
+and users are encouraged to use this updated version for their work.*
 
-   *To cite this package, plase use the original publication by Baum et al. (2019) as described below
-   or refer to the GitHub repository for the most recent updates and contributions.*
+*To cite this package, plase use the original publication by Baum et al. (2019) as described below
+or refer to the GitHub repository for the most recent updates and contributions.*
 
-   *Lukas Kopecky, April 2026.*
+*Lukas Kopecky, April 2026.*
 
 An easy to use Python package for (Multiblock) Partial Least Squares
 prediction modelling of univariate or multivariate outcomes. Four state

--- a/README.rst
+++ b/README.rst
@@ -12,20 +12,18 @@ Multiblock Partial Least Squares Package
    :target: https://doi.org/10.21105/joss.01190
    :alt: JOSS Paper DOI
 
-   .. note::
 
-      This is a newly maintained version of the package, based on the original
-      MBPLS software originally developed by Andreas Baum and Laurent Vermue 
-      (homepabe: https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/).
+   *This is a newly maintained version of the package, based on the original
+   MBPLS software originally developed by Andreas Baum and Laurent Vermue
+   (homepabe: https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/).
+   This maintained version has been updated to be compatible with Python 3.8 and later, and modern
+   version of the dependencies. The original version of the package is no longer maintained,
+   and users are encouraged to use this updated version for their work.*
 
-      This maintained version has been updated to be compatible with Python 3.8 and later, and modern
-      version of the dependencies. The original version of the package is no longer maintained, 
-      and users are encouraged to use this updated version for their work.
+   *To cite this package, plase use the original publication by Baum et al. (2019) as described below
+   or refer to the GitHub repository for the most recent updates and contributions.*
 
-      To cite this package, plase use the original publication by Baum et al. (2019) as described below 
-      or refer to the GitHub repository for the most recent updates and contributions.
-
-      Lukas Kopecky (l.kopecky22@imperial.ac.uk), April 2026.
+   *Lukas Kopecky, April 2026.*
 
 An easy to use Python package for (Multiblock) Partial Least Squares
 prediction modelling of univariate or multivariate outcomes. Four state

--- a/README.rst
+++ b/README.rst
@@ -13,17 +13,9 @@ Multiblock Partial Least Squares Package
    :alt: JOSS Paper DOI
 
 
-*This is a newly maintained version of the package, based on the original
-MBPLS software originally developed by Andreas Baum and Laurent Vermue
-(homepabe: https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/).
-This maintained version has been updated to be compatible with Python 3.8 and later, and modern
-version of the dependencies. The original version of the package is no longer maintained,
-and users are encouraged to use this updated version for their work.*
-
-*To cite this package, plase use the original publication by Baum et al. (2019) as described below
-or refer to the GitHub repository for the most recent updates and contributions.*
-
-*Lukas Kopecky, April 2026.*
+*This is a newly maintained version of the MBPLS software originally developed by Andreas Baum and Laurent Vermue
+(homepage: https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/). This maintained version has been updated to be compatible with Python 3.8 and later.
+Lukas Kopecky, April 2026.*
 
 An easy to use Python package for (Multiblock) Partial Least Squares
 prediction modelling of univariate or multivariate outcomes. Four state

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,7 @@
 Multiblock Partial Least Squares Package
 ========================================
 
-.. image:: https://img.shields.io/pypi/v/mbpls.svg
-    :target: https://pypi.python.org/pypi/mbpls
-    :alt: Pypi Version
-.. image:: https://travis-ci.com/DTUComputeStatisticsAndDataAnalysis/MBPLS.svg?branch=master
-   :target: https://travis-ci.com/DTUComputeStatisticsAndDataAnalysis/MBPLS
-   :alt: Build Status
+
 .. image:: https://img.shields.io/pypi/l/mbpls.svg
     :target: https://pypi.python.org/pypi/mbpls/
     :alt: License
@@ -16,6 +11,21 @@ Multiblock Partial Least Squares Package
 .. image:: http://joss.theoj.org/papers/10.21105/joss.01190/status.svg
    :target: https://doi.org/10.21105/joss.01190
    :alt: JOSS Paper DOI
+
+   .. note::
+
+      This is a newly maintained version of the package, based on the original
+      MBPLS software originally developed by Andreas Baum and Laurent Vermue 
+      (homepabe: https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/).
+
+      This maintained version has been updated to be compatible with Python 3.8 and later, and modern
+      version of the dependencies. The original version of the package is no longer maintained, 
+      and users are encouraged to use this updated version for their work.
+
+      To cite this package, plase use the original publication by Baum et al. (2019) as described below 
+      or refer to the GitHub repository for the most recent updates and contributions.
+
+      Lukas Kopecky (l.kopecky22@imperial.ac.uk), April 2026.
 
 An easy to use Python package for (Multiblock) Partial Least Squares
 prediction modelling of univariate or multivariate outcomes. Four state
@@ -27,7 +37,7 @@ toolbox.
 
 The documentation is available at https://mbpls.readthedocs.io
 and elaborate (real-world) Jupyter Notebook examples can be found at
-https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/tree/master/examples
+https://github.com/kopeckylukas/MB-PLS/tree/master/examples
 
 This package can be cited using the following reference. 
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Installation
 -  | Install the package for Python3 using the following command. Some
      dependencies might require an upgrade (scikit-learn, numpy and
      scipy).
-   | ``$ pip install multiblock-pls``
+   | ``$ pip install mb-pls``
 
 -  | Now you can import the MBPLS class by typing
    | ``from mbpls.mbpls import MBPLS``

--- a/mbpls/__init__.py
+++ b/mbpls/__init__.py
@@ -22,4 +22,4 @@ from . import mbpls, data
 
 __all__ = ["mbpls", "data"]
 
-__version__ = "1.0.4"
+__version__ = "1.1.0"

--- a/mbpls/mbpls.py
+++ b/mbpls/mbpls.py
@@ -358,7 +358,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
 
         self.W_ = []
         self.W_non_normal_ = []
-        if self.method is not 'SIMPLS':
+        if self.method != 'SIMPLS':
             self.A_ = np.empty((self.num_blocks_, 0))
             self.A_corrected_ = np.empty((self.num_blocks_, 0))
             self.T_ = []
@@ -372,7 +372,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
         for block in range(self.num_blocks_):
             self.W_.append(np.empty((X[block].shape[1], 0)))
             self.W_non_normal_.append(np.empty((X[block].shape[1], 0)))
-            if self.method is not 'SIMPLS':
+            if self.method != 'SIMPLS':
                 self.T_.append(np.empty((X[block].shape[0], 0)))
 
         # Concatenate X blocks
@@ -1124,7 +1124,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                     Y = Y.reshape(-1, 1)
                 Y = self.y_scaler_.transform(Y)
                 # Here the block scores are calculated iteratively for new blocks
-                if self.method is not 'SIMPLS': 
+                if self.method != 'SIMPLS': 
                     T_ = []
                     for block in range(self.num_blocks_):
                         T_.append(np.empty((X[block].shape[0], 0)))
@@ -1182,7 +1182,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                         U_ = Y.dot(self.V_) / np.linalg.norm(Y.dot(self.V_), axis=0)
                     return Ts_, U_
             else:
-                if self.method is not 'SIMPLS':
+                if self.method != 'SIMPLS':
                     # Here the block scores are calculated iteratively for new blocks
                     T_ = []
                     for block in range(self.num_blocks_):

--- a/mbpls/mbpls.py
+++ b/mbpls/mbpls.py
@@ -290,7 +290,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                 self.method = 'NIPALS'
 
         global U_, T_, R_
-        Y = check_array(Y, dtype=np.float64, ensure_2d=False, force_all_finite=not self.sparse_data, copy=self.copy)
+        Y = check_array(Y, dtype=np.float64, ensure_2d=False, ensure_all_finite=not self.sparse_data, copy=self.copy)
         if self.sparse_data is True:
             self.sparse_Y_info_ = {}
             self.sparse_Y_info_['Y'] = self.check_sparsity_level(Y)
@@ -308,14 +308,14 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                     # Check dimensions
                     check_consistent_length(X[block], Y)
                     X[block] = check_array(X[block], dtype=np.float64, copy=self.copy,
-                                           force_all_finite=not self.sparse_data)
+                                           ensure_all_finite=not self.sparse_data)
                     if self.sparse_data is True:
                         self.sparse_X_info_[block] = self.check_sparsity_level(X[block])
                     X[block] = self.x_scalers_[block].fit_transform(X[block])
             else:
                 self.x_scalers_.append(StandardScaler(with_mean=True, with_std=True))
                 # Check dimensions
-                X = check_array(X, dtype=np.float64, copy=self.copy, force_all_finite=not self.sparse_data)
+                X = check_array(X, dtype=np.float64, copy=self.copy, ensure_all_finite=not self.sparse_data)
                 if self.sparse_data is True:
                     self.sparse_X_info_ = {}
                     self.sparse_X_info_[0] = self.check_sparsity_level(X)
@@ -334,12 +334,12 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                     # Check dimensions
                     check_consistent_length(X[block], Y)
                     X[block] = check_array(X[block], dtype=np.float64, copy=self.copy,
-                                           force_all_finite=not self.sparse_data)
+                                           ensure_all_finite=not self.sparse_data)
                     if self.sparse_data is True:
                         self.sparse_X_info_[block] = self.check_sparsity_level(X[block])
             else:
                 # Check dimensions
-                X = check_array(X, dtype=np.float64, copy=self.copy, force_all_finite=not self.sparse_data)
+                X = check_array(X, dtype=np.float64, copy=self.copy, ensure_all_finite=not self.sparse_data)
                 if self.sparse_data is True:
                     self.sparse_X_info_ = {}
                     self.sparse_X_info_[0] = self.check_sparsity_level(X)
@@ -1091,13 +1091,13 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                     X = deepcopy(X)
                 for block in range(len(X)):
                     # Check dimensions
-                    X[block] = check_array(X[block], dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                    X[block] = check_array(X[block], dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
                     if self.sparse_data:
                         sparse_X_info_[block] = self.check_sparsity_level(X[block])
                     X[block] = self.x_scalers_[block].transform(X[block])
             else:
                 # Check dimensions
-                X = check_array(X, dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                X = check_array(X, dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
                 if self.sparse_data:
                     sparse_X_info_[0] = self.check_sparsity_level(X)
                 X = [self.x_scalers_[0].transform(X)]
@@ -1117,7 +1117,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                 Ts_ = X_comp.dot(self.R_)
 
             if Y is not None:
-                Y = check_array(Y, dtype=np.float64, ensure_2d=False, force_all_finite=not self.sparse_data, copy=copy)
+                Y = check_array(Y, dtype=np.float64, ensure_2d=False, ensure_all_finite=not self.sparse_data, copy=copy)
                 if self.sparse_data:
                     sparse_Y_info_['Y'] = self.check_sparsity_level(Y)
                 if Y.ndim == 1:
@@ -1225,12 +1225,12 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                     X = deepcopy(X)
                 for block in range(len(X)):
                     # Check dimensions
-                    X[block] = check_array(X[block], dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                    X[block] = check_array(X[block], dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
                     if self.sparse_data:
                         sparse_X_info_[block] = self.check_sparsity_level(X[block])
             else:
                 # Check dimensions
-                X = check_array(X, dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                X = check_array(X, dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
                 if self.sparse_data:
                     sparse_X_info_[0] = self.check_sparsity_level(X)
                 X = [X]
@@ -1250,7 +1250,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                 Ts_ = X_comp.dot(self.R_)
 
             if Y is not None:
-                Y = check_array(Y, dtype=np.float64, ensure_2d=False, force_all_finite=not self.sparse_data, copy=copy)
+                Y = check_array(Y, dtype=np.float64, ensure_2d=False, ensure_all_finite=not self.sparse_data, copy=copy)
                 if self.sparse_data:
                     sparse_Y_info_['Y'] = self.check_sparsity_level(Y)
                 if Y.ndim == 1:
@@ -1365,10 +1365,10 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                     X = deepcopy(X)
                 for block in range(len(X)):
                     # Check dimensions
-                    X[block] = check_array(X[block], dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                    X[block] = check_array(X[block], dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
                     X[block] = self.x_scalers_[block].transform(X[block])
             else:
-                X = check_array(X, dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                X = check_array(X, dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
                 X = [self.x_scalers_[0].transform(X)]
 
 
@@ -1390,9 +1390,9 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
                     X = deepcopy(X)
                 for block in range(len(X)):
                     # Check dimensions
-                    X[block] = check_array(X[block], dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                    X[block] = check_array(X[block], dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
             else:
-                X = check_array(X, dtype=np.float64, force_all_finite=not self.sparse_data, copy=copy)
+                X = check_array(X, dtype=np.float64, ensure_all_finite=not self.sparse_data, copy=copy)
                 X = [X]
             X = np.hstack(X)
             if self.sparse_data:

--- a/mbpls/mbpls.py
+++ b/mbpls/mbpls.py
@@ -1493,7 +1493,7 @@ class MBPLS(TransformerMixin, RegressorMixin, MultiOutputMixin, BaseEstimator):
             for block in range(self.num_blocks_):
                 # Inverse transforming weights/loadings
                 if self.standardize:
-                    P_inv_trans.append(self.x_scalers_[block].inverse_transform(self.P_[block][:, comp]))
+                    P_inv_trans.append(self.x_scalers_[block].inverse_transform(self.P_[block][:, comp].reshape(1, -1)).flatten())
                 else:
                     P_inv_trans.append(self.P_[block][:, comp])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.19.5
 scipy>=1.6.0
 scikit-learn>=1.6.0
 pandas>=2.0.0
+matplotlib>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.13.3
-scipy>=1.0.0
-scikit-learn>=0.20.0
-pandas>=0.20.0
+numpy>=1.19.5
+scipy>=1.6.0
+scikit-learn>=1.6.0
+pandas>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,11 @@
 
 from setuptools import setup, find_packages
 
-import mbpls
+# import mbpls
 
-NAME = "mb-pls"
-VERSION = mbpls.__version__
+NAME = "multiblock-pls"
+# VERSION = mbpls.__version__
+VERSION = '1.1.0'
 DESCRIPTION = "An implementation of the most common partial least squares algorithms as multi-block methods"
 URL = 'https://github.com/kopeckylukas/MB-PLS'
 AUTHORS = "Andreas Baum, Laurent Vermue, Lukas Kopecky"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 # import mbpls
 
-NAME = "mb-pls"
+NAME = "multiblock-pls"
 # VERSION = mbpls.__version__
 VERSION = '1.1.0'
 DESCRIPTION = "An implementation of the most common partial least squares algorithms as multi-block methods"

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ AUTHOR_MAILS = "<andba@dtu.dk>, <lauve@dtu.dk>"
 LICENSE = 'new BSD'
 
 # This is the lowest tested version. Below might work as well
-NUMPY_MIN_VERSION = '1.13.3'
-SCIPY_MIN_VERSION = '1.0.0'
-SCIKIT_LEARN_MIN_VERSION = '0.22.1'
-PANDAS_MIN_VERSION = '0.20.0'
+NUMPY_MIN_VERSION = '1.19.5'
+SCIPY_MIN_VERSION = '1.6.0'
+SCIKIT_LEARN_MIN_VERSION = '1.6.0'
+PANDAS_MIN_VERSION = '2.0.0'
 
 def setup_package():
     with open('README.rst') as f:
@@ -50,9 +50,12 @@ def setup_package():
                        'Operating System :: POSIX',
                        'Operating System :: Unix',
                        'Operating System :: MacOS',
-                       'Programming Language :: Python :: 3.5',
-                       'Programming Language :: Python :: 3.6',
-                       'Programming Language :: Python :: 3.7',
+                       'Programming Language :: Python :: 3.9',
+                       'Programming Language :: Python :: 3.10',
+                       'Programming Language :: Python :: 3.11',
+                       'Programming Language :: Python :: 3.12',
+                       'Programming Language :: Python :: 3.13',
+                       'Programming Language :: Python :: 3.14',
                        # 'Development Status :: 4 - Beta',
                        'Development Status :: 5 - Production/Stable'
                        ],
@@ -75,7 +78,7 @@ def setup_package():
                   'matplotlib',
               ],
           },
-          python_requires='>=3.5',
+          python_requires='>=3.9',
           )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ from setuptools import setup, find_packages
 
 import mbpls
 
-NAME = "mbpls"
+NAME = "mb-pls"
 VERSION = mbpls.__version__
 DESCRIPTION = "An implementation of the most common partial least squares algorithms as multi-block methods"
-URL = 'https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS'
-AUTHORS = "Andreas Baum, Laurent Vermue"
-AUTHOR_MAILS = "<andba@dtu.dk>, <lauve@dtu.dk>"
+URL = 'https://github.com/kopeckylukas/MB-PLS'
+AUTHORS = "Andreas Baum, Laurent Vermue, Lukas Kopecky"
+AUTHOR_MAILS = "<andba@dtu.dk>, <lauve@dtu.dk>, <l.kopecky22@imperial.ac.uk>"
 LICENSE = 'new BSD'
 
 # This is the lowest tested version. Below might work as well

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ NUMPY_MIN_VERSION = '1.19.5'
 SCIPY_MIN_VERSION = '1.6.0'
 SCIKIT_LEARN_MIN_VERSION = '1.6.0'
 PANDAS_MIN_VERSION = '2.0.0'
+MATPLOTLIB_MIN_VERSION = '3.0.0'
 
 def setup_package():
     with open('README.rst') as f:
@@ -63,7 +64,8 @@ def setup_package():
               'numpy>={0}'.format(NUMPY_MIN_VERSION),
               'scipy>={0}'.format(SCIPY_MIN_VERSION),
               'scikit-learn>={0}'.format(SCIKIT_LEARN_MIN_VERSION),
-              'pandas>={0}'.format(PANDAS_MIN_VERSION)
+              'pandas>={0}'.format(PANDAS_MIN_VERSION),
+              'matplotlib>={0}'.format(MATPLOTLIB_MIN_VERSION)
                 ],
           extras_require={
               'tests': [
@@ -73,9 +75,6 @@ def setup_package():
                   'sphinx_rtd_theme',
                   'nbsphinx',
                   'nbsphinx_link'
-                    ],
-              'extras': [
-                  'matplotlib',
               ],
           },
           python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 # import mbpls
 
-NAME = "multiblock-pls"
+NAME = "mb-pls"
 # VERSION = mbpls.__version__
 VERSION = '1.1.0'
 DESCRIPTION = "An implementation of the most common partial least squares algorithms as multi-block methods"


### PR DESCRIPTION
## Contributing to bug fixes

 - Fill out the template below
 - The pull request should only fix existing bug reports
 - The pull request should comply with these points mentioned in [the contribution guidelines](https://github.com/DTUComputeStatisticsAndDataAnalysis/MBPLS/blob/master/.github/CONTRIBUTING.md#pull-request)
 
 ### Link to the relevant Bug(s)

Fixes Issues:
- #12 
- #13 
- #14 

 
### Description of the Change

**For #12** 
- Fix sklearn compatibility: reshape 1D array in plot method StandardScaler.inverse_transform now requires 2D input in newer versions of scikit-learn (from scikit-learn version 1.0 and later). Reshape the loadings slice to 2D before inverse transforming and flatten the result.

**For #13**
- Change attribute force_all_finite to ensure_all_finite in check_array function  to ensure compatibility with scikit-learn version 1.6 and later.  force_all_finite was removed in scikit-learn version 1.8 

**For #14** 
- resolve syntax warning introduced in Python 3.8 when comparing two strings using `is not` instead of `!=`. (SyntaxWarning: "is not" with 'str' literal. Did you mean "!="? if self.method is not 'SIMPLS'). `is not` compares object identity, not value.



### Possible Drawbacks

The behaviour was only tested for the latest versions of Python (3.11 and later) and dependencies (scikit-learn v1.6 and later). This bridges the gap of over 6 years since the last release. It is possible that these changes will not work for intermediate versions of packages. 

Further, the updated version does not pass pytests. However, this code did not introduce any changes to the code itself and only addressed Syntax and Type errors caused by dependencies API changes. The failed pytest are likely due to changes in the way random seeds are handled when data are generated. 



### Verification Process

Run example code to ensure the code can now be run without errors and future warnings, and attempted to run existing unit tests. The result of those tests described in Possible Drawbacks section. 



### Release Notes

- Fixed scikit-learn compatibility issue where StandardScaler.inverse_transform requires 2D input (scikit-learn ≥1.0) by reshaping the loadings slice in the plot method (#12).

- Replaced deprecated force_all_finite parameter with ensure_all_finite in check_array calls for compatibility with scikit-learn ≥1.6 (#13).

- Fixed SyntaxWarning by replacing identity comparison (is not) with value comparison (!=) for string literals (#14).
